### PR TITLE
Add Variables For Defining Docker & Compose Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 Use this role to install the latest stable release of Docker Community Edition on Ubuntu 16.04 Xenial.
 
 This role was built with the instructions found at https://docs.docker.com/install/linux/docker-ce-ubuntu/
+
+## Variables
+
+- `docker_version` - The version of the Docker Daemon to install
+- `docker_compose_version` - The version of docker-compose to install
+- `docker_install_docker_compose` - Whether to install docker-compose or not. The default value is `True`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,5 @@
 ---
 # Defaults file for Docker-CE installation
+docker_version: "18.06.1*"
+docker_compose_version: "1.23.2"
+docker_install_docker_compose: True

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 # Handlers file for Docker-CE installation
 
-- name: Start docker-ce service
+- name: restart docker
   service:
     name: docker
-    state: started
+    state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,3 +12,4 @@ galaxy_info:
   categories:
     - docker
     - docker-ce
+    - docker-compose

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,9 +35,11 @@
 
 - name: Install docker-ce
   apt:
-    name: docker-ce
-    state: latest
+    name: "docker-ce={{ docker_version }}"
+    state: "present"
     update_cache: yes
+  notify:
+    - restart docker
 
 - name: Run docker-ce as a service
   service:
@@ -45,14 +47,10 @@
     state: started
     enabled: yes
 
-- name: Get Docker Compose download json
-  uri:
-    url: "https://api.github.com/repos/docker/compose/releases/latest"
-  register: github_response
-
 - name: Download Docker Compose
   get_url:
-    url: "https://github.com/docker/compose/releases/download/{{github_response.json.tag_name}}/docker-compose-{{ansible_system}}-{{ansible_architecture}}"
+    url: "https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-{{ ansible_system }}-{{ ansible_architecture }}"
     dest: "/usr/local/bin/docker-compose"
     force: false
     mode: '0555'
+  when: docker_install_docker_compose


### PR DESCRIPTION
To allow for idempotent builds, add two variables for specifying which
versions of the Docker daemon and docker-compose to install.

Also add a variable to control whether docker-compose should be
installed or not.

Signed-off-by: Jason Rogena