### PR TITLE
support multiple processor architectures

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -31,7 +31,7 @@
 
 - name: Setup stable docker-ce repository
   apt_repository:
-    repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ansible_distribution_release}} stable"
+    repo: "deb [arch={{ deb_architecture[ansible_architecture] }}] https://download.docker.com/linux/ubuntu {{ansible_distribution_release}} stable"
     state: present
 
 - name: Install Docker Engine, containerd, and Docker Compose

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,11 @@
 ---
 # Vars file for Docker-CE installation
 docker_group: docker
+deb_architecture:
+  {
+    "x86_64": "amd64",
+    "aarch64": "arm64",
+    "armv6l": "armhf",
+    "armv7l": "armhf",
+    "i386": "i386",
+  }


### PR DESCRIPTION
- The Amazon EC2 T4g instances are powered by Arm-based AWS Graviton2 processors. See more [here](https://aws.amazon.com/ec2/instance-types/t4/)